### PR TITLE
remove throw from gdaljl_errorhandler

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -32,15 +32,13 @@ checking code decides it should throw.
 function gdaljl_errorhandler(class::CPLErr, errno::Cint, errmsg::Cstring)
     # function signature needs to match the one in __init__, and the signature
     # of the callback for a custom error handler in the GDAL docs
-    if class === CE_Failure
-        throw(GDALError(class, errno, unsafe_string(errmsg)))
-    end
+    # return C_NULL to suppress any error printing by gdal
     return C_NULL
 end
 
 "Check the last error type and throw a GDALError if it is a failure"
 function maybe_throw()
-    if cplgetlasterrortype() === CE_Failure
+    if cplgetlasterrortype() >= CE_Warning
         throw(GDALError())
     end
     nothing


### PR DESCRIPTION
The throw interrupts control flow on the C side, e.g. suppressing the closing of file descriptors when the error is caught by julia. This PR removes it, but leaves the error handler in place, so that printing by GDAL is suppressed. Furthermore, maybe_throw now also throws on fatal errors. Locally, all test pass.

ref https://github.com/rafaqz/Rasters.jl/issues/455